### PR TITLE
Allow change of server url (to support remote access or WSL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Can be used from the terminal, then always prefix the calls with `npx`. Use `npx
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | authToken               | The only required option, it can also be read from package.json. See the [VSCode extension](https://github.com/bitburner-official/bitburner-vscode) for information about how to retrieve it.                                               |
 | scriptRoot              | The folder that you want to sync. Defaults to the current folder. The directory node_modules is ignored but any other valid game files are synced. It's highly recommended to do a dryRun first to list all the files that would be synced. |
+| serverUrl               | The server to connect to (defaults to 127.0.0.1) |
 | allowDelete [^footnote] | If the sync (upload and retrieve) should be allowed to delete files at the target                                                                                                                                                           |
 | get [^footnote]         | Retrieve files from bitburner and store at scriptRoot                                                                                                                                                                                       |
 | dryRun                  | Doesn't sync the files, simply lists them in the terminal.                                                                                                                                                                                  |
@@ -47,7 +48,8 @@ Optional config
   "config": {
     "bitburnerAuthToken": "abc",
     "bitburnerScriptRoot": "./dist",
-    "bitburnerAllowDelete": "false"
+    "bitburnerAllowDelete": "false",
+    "bitburnerServerUrl": "127.0.0.1"
   }
 }
 ```
@@ -62,7 +64,8 @@ NB: The config inside package.json will override this config if both are specifi
 {
   "authToken": "abc",
   "scriptRoot": "./dist",
-  "allowDelete": false
+  "allowDelete": false,
+  "serverUrl": "127.0.0.1"
 } 
 ```
 

--- a/src/client.js
+++ b/src/client.js
@@ -32,6 +32,7 @@ export const uploadFileToBitburner = payload => {
     'POST',
     file.blob,
     payload.authToken,
+    payload.serverUrl,
     (res, body) => {
       switch (res.statusCode) {
         case 200:
@@ -52,13 +53,14 @@ export const uploadFileToBitburner = payload => {
  * @param {string} authToken
  * @returns {Promise<BitburnerFiles[]>}
  */
-export const getFilesFromBitburner = authToken => {
+export const getFilesFromBitburner = (authToken, serverUrl) => {
   const deferred = getDeferred();
 
   sendRequestToBitburner(
     'GET',
     '{}',
     authToken,
+    serverUrl,
     (res, body) => {
       if (body === 'not a script file') {
         logMessage(true, undefined, 'The bitburner client is too old for retrieval', undefined);
@@ -107,6 +109,7 @@ export const deleteFileAtBitburner = payload => {
     'DELETE',
     file.blob,
     payload.authToken,
+    payload.serverUrl,
     (res, body) => {
       switch (res.statusCode) {
         case 200:
@@ -176,9 +179,9 @@ const logMessage = (isError, filename, message, body) => {
  * @param {string} authToken
  * @param {sendRequestToBitburner-callback} responseHandler
  */
-const sendRequestToBitburner = (method, blob, authToken, responseHandler) => {
+const sendRequestToBitburner = (method, blob, authToken, serverUrl, responseHandler) => {
   const options = {
-    hostname: bitburnerConfig.url,
+    hostname: serverUrl || bitburnerConfig.url,
     port: bitburnerConfig.port,
     path: bitburnerConfig.fileURI,
     method,

--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,12 @@ const getConfig = () => {
       default: false,
       env: 'npm_package_config_bitburnerAllowDelete',
     },
+    serverUrl: {
+      doc: 'Connect to this Url',
+      format: 'String',
+      default: '127.0.0.1',
+      env: 'npm_package_config_bitburnerServerUrl',
+    },
   });
 
   const configPath = path.join(process.cwd(), configFileName);
@@ -64,6 +70,11 @@ export const getArgs = () => {
       type: 'boolean',
       default: config.get('allowDelete'),
     })
+    .option('serverUrl', {
+      describe: 'Server to connect to',
+      type: 'string',
+      default: config.get('serverUrl'),
+    })
     .option('watch', {
       describe: 'To continuously watch the script root for changes',
       type: 'boolean',
@@ -91,6 +102,7 @@ export const getArgs = () => {
     config: {
       scriptRoot: path.resolve(process.cwd(), args.scriptRoot),
       authToken: args.authToken,
+      serverUrl: args.serverUrl,
       allowDelete,
     },
     doWatch,

--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,7 @@ export const sync = async (config, dryRun) => {
         filename,
         code,
         authToken: config.authToken,
+        serverUrl: config.serverUrl
       });
   }
 
@@ -83,6 +84,7 @@ export const sync = async (config, dryRun) => {
       deleteFileAtBitburner({
         filename: file.filename,
         authToken: config.authToken,
+        serverUrl: config.serverUrl
       });
   }
 };
@@ -103,6 +105,7 @@ export const watch = config => {
       filename,
       code: contents,
       authToken: config.authToken,
+      serverUrl: config.serverUrl
     });
   };
 
@@ -110,6 +113,7 @@ export const watch = config => {
     deleteFileAtBitburner({
       filename,
       authToken: config.authToken,
+      serverUrl: config.serverUrl
     });
   };
 

--- a/typings/bitburner-sync.d.ts
+++ b/typings/bitburner-sync.d.ts
@@ -2,6 +2,7 @@ interface SyncConfig {
     scriptRoot: string;
     authToken: string;
     allowDelete: boolean;
+    serverUrl: string;
 }
 
 interface ConfigResult {


### PR DESCRIPTION
This PR allows to set the server Url either on the command line or by providing appropriate information in the configs.

This allows using bitburner-sync with WSL by using `-serverUrl "$(hostname).local"` 